### PR TITLE
Update parent SciJava POM version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>12.0.0</version>
+		<version>14.0.0</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
Update parent SciJava POM version from 12.0.0 to 14.0.0 (Last updated 23-Feb-2017).