### PR TITLE
Set plugins.dir correctly for paths that contain spaces

### DIFF
--- a/src/main/java/com/mycompany/imagej/Process_Pixels.java
+++ b/src/main/java/com/mycompany/imagej/Process_Pixels.java
@@ -171,7 +171,7 @@ public class Process_Pixels implements PlugInFilter {
 	public static void main(String[] args) {
 		// set the plugins.dir property to make the plugin appear in the Plugins menu
 		Class<?> clazz = Process_Pixels.class;
-		String url = clazz.getResource("/" + clazz.getName().replace('.', '/') + ".class").toString();
+		String url = clazz.getResource("/" + clazz.getName().replace('.', '/') + ".class").toString().replace("%20", " ");
 		String pluginsDir = url.substring("file:".length(), url.length() - clazz.getName().length() - ".class".length());
 		System.setProperty("plugins.dir", pluginsDir);
 


### PR DESCRIPTION
In Process_Pixels, `plugins.dir` is set manually to the outpath of the
compiled .class files by querying `class.getResource`.
However, this does not work if the path contains whitespaces that are
escaped by `getResource`.

This PR fixes this issue for spaces by replacing their escape code
(`%20`) by the original character.