### PR TITLE
Change the default location of the menu entry

### DIFF
--- a/src/main/resources/plugins.config
+++ b/src/main/resources/plugins.config
@@ -5,4 +5,4 @@
 # If something like ("<arg>") is appended to the class name, the setup() method
 # will get that as arg parameter; otherwise arg is simply the empty string.
 
-Process, "Process Pixels", com.mycompany.imagej.Process_Pixels
+Plugins, "Process Pixels", com.mycompany.imagej.Process_Pixels

--- a/src/main/resources/plugins.config
+++ b/src/main/resources/plugins.config
@@ -5,4 +5,4 @@
 # If something like ("<arg>") is appended to the class name, the setup() method
 # will get that as arg parameter; otherwise arg is simply the empty string.
 
-Plugins, "Process Pixels", com.mycompany.imagej.Process_Pixels
+Plugins>My Plugins, "Process Pixels", com.mycompany.imagej.Process_Pixels


### PR DESCRIPTION
Hi @ctrueden,

I'd like to suggest changing the default location of that example plugin / template. This could prevent some confusion for first-time plugin developers. See a maybe related discussion [here](https://forum.image.sc/t/use-of-process-pixels-0-1-0-snapshot-jar-as-imagej1-plugins/40871/5)  in the forum. 

Furthermore, if you would like to get rid of some repositories you maintain: I'm offering to take this one here over.

Cheers,
Robert